### PR TITLE
use sale-price instead regular price if set

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fond-of-spryker/google-microdata",
-    "description": "n/a",
+    "description": "provides google structured product data feed (json)",
     "license": "MIT",
     "authors": [
         {
@@ -17,8 +17,7 @@
     },
     "require-dev": {
       "spryker/code-sniffer": "^0.14.7",
-      "fond-of-codeception/spryker": "dev-master as 1.0.0",
-      "codeception/codeception": "^2.5",
+      "fond-of-codeception/spryker": "^1.0",
       "mikey179/vfsstream": "^1.6",
       "php-coveralls/php-coveralls": "^2.1",
       "sebastian/phpcpd": "^4.1"

--- a/src/FondOfSpryker/Yves/GoogleMicrodata/Plugin/FeedBuilder/ProductFeedBuilderPlugin.php
+++ b/src/FondOfSpryker/Yves/GoogleMicrodata/Plugin/FeedBuilder/ProductFeedBuilderPlugin.php
@@ -112,7 +112,7 @@ class ProductFeedBuilderPlugin extends AbstractPlugin implements FeedBuilderInte
         $offer = [
             GoogleMicrodataConstants::TYPE => GoogleMicrodataConstants::TYPE_OFFER,
             GoogleMicrodataConstants::PRODUCT_CURRENCY => $currency,
-            GoogleMicrodataConstants::PRODUCT_PRICE => $price,
+            GoogleMicrodataConstants::PRODUCT_PRICE => $salePrice !== null ? $salePrice : $price,
             GoogleMicrodataConstants::PRODUCT_URL => $this->getUrl($productViewTransfer),
             GoogleMicrodataConstants::PRODUCT_AVAILABILITY => $this->getAvailability($productViewTransfer),
         ];
@@ -121,7 +121,7 @@ class ProductFeedBuilderPlugin extends AbstractPlugin implements FeedBuilderInte
             return $offer;
         }
 
-        return array_merge($offer, [GoogleMicrodataConstants::PRODUCT_SALE_PRICE => $salePrice]);
+        return $offer;
     }
 
     /**

--- a/src/FondOfSpryker/Yves/GoogleMicrodata/Plugin/Provider/GoogleMicrodataTwigServiceProvider.php
+++ b/src/FondOfSpryker/Yves/GoogleMicrodata/Plugin/Provider/GoogleMicrodataTwigServiceProvider.php
@@ -8,7 +8,6 @@ use Spryker\Yves\Kernel\AbstractPlugin;
 use Twig_Environment;
 
 /**
- * @package FondOfSpryker\Yves\GoogleMicrodata\Plugin\Provider
  * @method \FondOfSpryker\Yves\GoogleMicrodata\GoogleMicrodataFactory getFactory()
  */
 class GoogleMicrodataTwigServiceProvider extends AbstractPlugin implements ServiceProviderInterface


### PR DESCRIPTION
**Changelog**

Currently, google cannot read the offer prices. for the black friday sale we will overwrite the regular prices with the offer prices so that the offers are correctly listed in the google shopping feed.